### PR TITLE
Less strict type requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Tests, Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1' 
+          - '1.0'
+          - '1.3'
+        os:
+          - [ubuntu-latest]
+        arch:
+          - x64
+    steps:
+      # Cancel ongoing CI test runs if pushing to branch again before the previous tests 
+      # have finished
+      - name: Cancel ongoing test runs for previous commits
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      # Do tests
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ connectivity = delaunay(coordinates)
  1  1
 ```
 
+### Vectors of SVector
+
+You may want to use a `Vector{SVector}`, where `SVector` is from
+[StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl), to represent your
+points. If so, you can use `reinterpret` to represent the points in component major order.
+
+```julia
+using MiniQhull, StaticArrays
+dim = 5
+npts = 100
+pts = [SVector{dim, Float64}(rand(dim)) for i = 1:npts];
+flags = "qhull d Qbb Qc QJ Pp" # custom flags
+connectivity = delaunay(dim, npts, reinterpret(Float64, pts), flags)
+```
+
 ## Installation
 
 `MiniQhull` is a registered Julia package. If your system fulfills all the requirements (see below), `MiniQhull` can be installed using the command:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The `MiniQhull` julia package provides a single function `delaunay` overloaded with 2 methods:
 
 ```julia
-delaunay(dim::Integer, numpoints::Integer, points::Vector) -> Matrix{Int32}
+delaunay(dim::Integer, numpoints::Integer, points::AbstractVector) -> Matrix{Int32}
 ```
 Compute the Delaunay triangulation of a cloud of points in an arbitrary dimension `dim`. The length of vector `points` must be `dim*numpoints`. Vector `points` holds data in "component major order", i.e., components are consequitive within the vector. The returned matrix has shape `(dim+1, nsimplices)`, where `nsimplices` is the number of
 simplices in the computed Delaunay triangulation.
@@ -24,12 +24,10 @@ You can override the default set of flags that Qhull uses by passing
 an additional `flags` argument:
 
 ```julia
-delaunay(dim::Integer, numpoints::Integer, points::Vector, flags::AbstractString) -> Matrix{Int32}
+delaunay(dim::Integer, numpoints::Integer, points::AbstractVector, flags::AbstractString) -> Matrix{Int32}
 delaunay(points::Matrix, flags::AbstractString) -> Matrix{Int32}
 ```
 The default set of flags is `qhull d Qt Qbb Qc Qz` for up to 3 dimensions, and `qhull d Qt Qbb Qc Qx` for higher dimensions. The flags you pass override the default flags, i.e. you have to pass all the flags that Qhull should use.
-
-
 
 ## Examples
 

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -24,7 +24,7 @@ end
 
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == length(points)
-    _delaunay(Int32(dim), Int32(numpoints), points, flags)
+    _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
 end
 
 function delaunay(points::Matrix,

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -7,7 +7,7 @@ export delaunay
 include("load.jl")
 include("bindings.jl")
 
-function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T<:Real
+function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{Float64}, flags::Union{Nothing,AbstractString})
     numcells = Ref{Int32}()
     qh = new_qhull_handler()
     qh == C_NULL && error("Qhull handler is null")
@@ -22,7 +22,7 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags
     cells
 end
 
-function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{Float64}, flags::Union{Nothing,AbstractString}=nothing) 
     @assert numpoints*dim == length(points)
     _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
 end

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -22,7 +22,7 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{Float64},
     cells
 end
 
-function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T <: Int
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == length(points)
     _delaunay(Int32(dim), Int32(numpoints), float.(points), flags)
 end

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -22,10 +22,18 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{Float64},
     cells
 end
 
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T <: Int
+    @assert numpoints*dim == length(points)
+    _delaunay(Int32(dim), Int32(numpoints), float.(points), flags)
+end
+
+# If input data are already Float64, then no conversion is needed
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{Float64}, flags::Union{Nothing,AbstractString}=nothing) 
     @assert numpoints*dim == length(points)
-    _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
+    _delaunay(Int32(dim), Int32(numpoints), points, flags)
 end
+
+
 
 function delaunay(points::Matrix,
     flags::Union{Nothing,AbstractString}=nothing)

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -7,7 +7,7 @@ export delaunay
 include("load.jl")
 include("bindings.jl")
 
-function _delaunay(dim::Int32, numpoints::Int32, points::Array{Float64}, flags::Union{Nothing,AbstractString}) 
+function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T
     numcells = Ref{Int32}()
     qh = new_qhull_handler()
     qh == C_NULL && error("Qhull handler is null")
@@ -22,8 +22,7 @@ function _delaunay(dim::Int32, numpoints::Int32, points::Array{Float64}, flags::
     cells
 end
 
-function delaunay(dim::Integer, numpoints::Integer, points::Vector,
-                  flags::Union{Nothing,AbstractString}=nothing)
+function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
     @assert numpoints*dim == size(points,1)
     _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
 end

--- a/src/MiniQhull.jl
+++ b/src/MiniQhull.jl
@@ -7,7 +7,7 @@ export delaunay
 include("load.jl")
 include("bindings.jl")
 
-function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T
+function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags::Union{Nothing,AbstractString}) where T<:Real
     numcells = Ref{Int32}()
     qh = new_qhull_handler()
     qh == C_NULL && error("Qhull handler is null")
@@ -23,8 +23,8 @@ function _delaunay(dim::Int32, numpoints::Int32, points::AbstractArray{T}, flags
 end
 
 function delaunay(dim::Integer, numpoints::Integer, points::AbstractVector{T}, flags::Union{Nothing,AbstractString}=nothing) where T
-    @assert numpoints*dim == size(points,1)
-    _delaunay(Int32(dim), Int32(numpoints), Vector{Float64}(points), flags)
+    @assert numpoints*dim == length(points)
+    _delaunay(Int32(dim), Int32(numpoints), points, flags)
 end
 
 function delaunay(points::Matrix,

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -6,7 +6,7 @@ function new_qhull_handler()
 end
 
 # int delaunay_init_and_compute( int dim, int numpoints, coordT *points, int* numcells);
-function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::Array{Float64}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString})
+function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{T}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString}) where T
     @check_if_loaded
     ccall(delaunay_init_and_compute_c[], 
         Cint, (

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -6,7 +6,7 @@ function new_qhull_handler()
 end
 
 # int delaunay_init_and_compute( int dim, int numpoints, coordT *points, int* numcells);
-function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{T}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString}) where T
+function delaunay_init_and_compute(qh::Ptr{Cvoid}, dim::Int32, numpoints::Int32, points::AbstractArray{Float64}, numcells::Ref{Int32}, flags::Union{Ptr{Nothing},AbstractString})
     @check_if_loaded
     ccall(delaunay_init_and_compute_c[], 
         Cint, (


### PR DESCRIPTION
## Problem 

When working with points in (low-ish) N-dimensional space, it is typical in Julia to represent these points by statically sized vectors using the `SVector` type from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl). To pass these points on to `MiniQhull.delaunay`, I first have to gather the points, then convert them to a vector with column-major ordering. 

```julia
using MiniQhull, StaticArrays
dim = 5
npts = 300
pts = [SVector{dim, Float64}(rand(dim) for i = 1:npts]

# Works, but is veery slow and allocates a lot of memory
x = Array(vcat(pts...,))
delaunay(dim, npts, x)
```

However, it is possible to `reinterpret` the points as a column-major vector with almost zero extra cost. But currently, using reinterpreted data doesn't work with `MiniQhull.delaunay` because it is hard-coded that the input points must be a Vector{Float64}. 

```julia
using MiniQhull, StaticArrays
dim = 5
npts = 300
pts = [SVector{dim, Float64}(rand(dim) for i = 1:npts]

# This operation is fast/allocates almost nothing
x = reinterpret(Float64, pts) #`x` is now of type `Base.ReinterpretArray`

# Fails, because the input must be `Vector{Float64}`
delaunay(dim, npts, x)
```

In my applications, the first approach becomes very slow, and it is crucial performance-wise to be able to do the latter. I could just re-write my own version `MiniQhull.delaunay` in upstream packages, but I guess this could be useful for other people too.

## Solution 

This PR solves this problem by having less strict type requirements (i.e. using `AbstractVector`/`AbstractArray` instead of `Vector`/`Array`). 

## Documentation

I added an extra use case to the documentation, similar to the examples above, highlighting how reinterpreted static vectors can be used as input to `delaunay`.